### PR TITLE
Configure build-scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: groovy
-script: ./gradlew clean build  --info --no-daemon
+script: ./gradlew clean build  --info --no-daemon --scan
 jdk:
  - oraclejdk8
 # - openjdk11

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'com.gradle.build-scan' version '1.16'
     id 'groovy'
     id 'maven'
     id 'org.ysb33r.bintray' version '1.5'
@@ -7,6 +8,11 @@ plugins {
     id 'com.jfrog.artifactory' version '3.0.1'
     id 'com.github.hierynomus.license' version '0.14.0'
     id 'com.gradle.plugin-publish' version '0.9.7'
+}
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 apply from : 'gradle/download-tests.gradle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.daemon   = true
+org.gradle.caching  = true
+org.gradle.parallel = true


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.